### PR TITLE
Support quest generation with JSON response schema

### DIFF
--- a/app/src/main/java/com/povush/aiadvent/MainActivity.kt
+++ b/app/src/main/java/com/povush/aiadvent/MainActivity.kt
@@ -42,6 +42,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -212,7 +213,7 @@ private fun MessagesList(
 
 @Composable
 private fun QuestCard(quest: QuestDto, modifier: Modifier = Modifier) {
-    var expanded by remember { mutableStateOf(true) }
+    var expanded by remember { mutableStateOf(false) }
     val checks = remember(quest.tasks) {
         mutableStateListOf<Boolean>().apply { repeat(quest.tasks.size) { add(false) } }
     }

--- a/app/src/main/java/com/povush/aiadvent/MainActivity.kt
+++ b/app/src/main/java/com/povush/aiadvent/MainActivity.kt
@@ -68,7 +68,6 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun ChatApp(vm: ChatViewModel = hiltViewModel()) {
     val state by vm.state.collectAsState()
-    LaunchedEffect(Unit) { vm.loadQuest() }
     MaterialTheme {
         Scaffold(
             topBar = {
@@ -116,7 +115,7 @@ fun ChatApp(vm: ChatViewModel = hiltViewModel()) {
                         )
                         Spacer(Modifier.width(8.dp))
                         FilledIconButton(
-                            onClick = { vm.send(stream = true) },
+                            onClick = { vm.send() },
                             enabled = !state.isStreaming && state.input.isNotBlank(),
                             shape = RoundedCornerShape(6.dp)
                         ) {
@@ -135,14 +134,6 @@ fun ChatApp(vm: ChatViewModel = hiltViewModel()) {
                         color = MaterialTheme.colorScheme.error,
                         style = MaterialTheme.typography.bodySmall,
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                    )
-                }
-                state.quest?.let {
-                    QuestCard(
-                        quest = it,
-                        modifier = Modifier
-                            .padding(horizontal = 16.dp, vertical = 8.dp)
-                            .fillMaxWidth()
                     )
                 }
                 MessagesList(
@@ -171,26 +162,40 @@ private fun MessagesList(
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         itemsIndexed(messages) { _, msg ->
-            val isUser = msg.role == "user"
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start
-            ) {
-                Surface(
-                    color = if (isUser) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainer,
-                    tonalElevation = 1.dp,
-                    shape = MaterialTheme.shapes.medium
+            if (msg.quest != null) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Start
                 ) {
-                    Column(Modifier
-                        .widthIn(max = 520.dp)
-                        .padding(12.dp)) {
-                        Text(
-                            text = if (isUser) "Ты" else "ПовБот \uD83E\uDD16",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                        Spacer(Modifier.height(4.dp))
-                        Text(msg.content, style = MaterialTheme.typography.bodyMedium)
+                    QuestCard(
+                        quest = msg.quest,
+                        modifier = Modifier.widthIn(max = 520.dp)
+                    )
+                }
+            } else {
+                val isUser = msg.role == "user"
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start
+                ) {
+                    Surface(
+                        color = if (isUser) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainer,
+                        tonalElevation = 1.dp,
+                        shape = MaterialTheme.shapes.medium
+                    ) {
+                        Column(
+                            Modifier
+                                .widthIn(max = 520.dp)
+                                .padding(12.dp)
+                        ) {
+                            Text(
+                                text = if (isUser) "Ты" else "ПовБот \uD83E\uDD16",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Spacer(Modifier.height(4.dp))
+                            Text(msg.content, style = MaterialTheme.typography.bodyMedium)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/povush/aiadvent/MainActivity.kt
+++ b/app/src/main/java/com/povush/aiadvent/MainActivity.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.povush.aiadvent.ui.ChatViewModel
+import com.povush.aiadvent.data.QuestDto
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -67,6 +68,7 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun ChatApp(vm: ChatViewModel = hiltViewModel()) {
     val state by vm.state.collectAsState()
+    LaunchedEffect(Unit) { vm.loadQuest() }
     MaterialTheme {
         Scaffold(
             topBar = {
@@ -135,6 +137,14 @@ fun ChatApp(vm: ChatViewModel = hiltViewModel()) {
                         modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
                     )
                 }
+                state.quest?.let {
+                    QuestCard(
+                        quest = it,
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp, vertical = 8.dp)
+                            .fillMaxWidth()
+                    )
+                }
                 MessagesList(
                     messages = state.messages,
                     modifier = Modifier.weight(1f)
@@ -184,6 +194,21 @@ private fun MessagesList(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun QuestCard(quest: QuestDto, modifier: Modifier = Modifier) {
+    Surface(
+        modifier = modifier,
+        tonalElevation = 2.dp,
+        shape = RoundedCornerShape(12.dp)
+    ) {
+        Column(Modifier.padding(16.dp)) {
+            Text(quest.title, style = MaterialTheme.typography.titleMedium)
+            Spacer(Modifier.height(4.dp))
+            Text(quest.description, style = MaterialTheme.typography.bodyMedium)
         }
     }
 }

--- a/app/src/main/java/com/povush/aiadvent/MainActivity.kt
+++ b/app/src/main/java/com/povush/aiadvent/MainActivity.kt
@@ -85,7 +85,7 @@ fun ChatApp(vm: ChatViewModel = hiltViewModel()) {
                                     .padding(
                                         top = 8.dp
                                     )
-                                    .fillMaxWidth()
+                                    .fillMaxWidth(),
                             )
                         }
                     }
@@ -125,9 +125,11 @@ fun ChatApp(vm: ChatViewModel = hiltViewModel()) {
                 }
             }
         ) { inner ->
-            Column(Modifier
-                .fillMaxSize()
-                .padding(inner)) {
+            Column(
+                Modifier
+                    .fillMaxSize()
+                    .padding(inner)
+            ) {
                 if (state.error != null) {
                     Text(
                         text = state.error ?: "",
@@ -148,7 +150,7 @@ fun ChatApp(vm: ChatViewModel = hiltViewModel()) {
 @Composable
 private fun MessagesList(
     messages: List<ChatViewModel.Message>,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val listState = rememberLazyListState()
     LaunchedEffect(messages.size) {
@@ -217,3 +219,4 @@ private fun QuestCard(quest: QuestDto, modifier: Modifier = Modifier) {
         }
     }
 }
+

--- a/app/src/main/java/com/povush/aiadvent/MainActivity.kt
+++ b/app/src/main/java/com/povush/aiadvent/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -24,6 +25,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledIconButton
 import androidx.compose.material3.HorizontalDivider
@@ -37,6 +39,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -207,15 +212,36 @@ private fun MessagesList(
 
 @Composable
 private fun QuestCard(quest: QuestDto, modifier: Modifier = Modifier) {
+    var expanded by remember { mutableStateOf(true) }
+    val checks = remember(quest.tasks) {
+        mutableStateListOf<Boolean>().apply { repeat(quest.tasks.size) { add(false) } }
+    }
     Surface(
         modifier = modifier,
         tonalElevation = 2.dp,
         shape = RoundedCornerShape(12.dp)
     ) {
         Column(Modifier.padding(16.dp)) {
-            Text(quest.title, style = MaterialTheme.typography.titleMedium)
-            Spacer(Modifier.height(4.dp))
-            Text(quest.description, style = MaterialTheme.typography.bodyMedium)
+            Text(
+                quest.title,
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.clickable { expanded = !expanded }
+            )
+            if (expanded) {
+                Spacer(Modifier.height(4.dp))
+                Text(quest.description, style = MaterialTheme.typography.bodyMedium)
+                quest.tasks.forEachIndexed { index, task ->
+                    Spacer(Modifier.height(8.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Checkbox(
+                            checked = checks.getOrNull(index) ?: false,
+                            onCheckedChange = { if (index < checks.size) checks[index] = it }
+                        )
+                        Spacer(Modifier.width(8.dp))
+                        Text(task, style = MaterialTheme.typography.bodyMedium)
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/povush/aiadvent/data/ChatRepository.kt
+++ b/app/src/main/java/com/povush/aiadvent/data/ChatRepository.kt
@@ -1,5 +1,7 @@
 package com.povush.aiadvent.data
 
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
@@ -8,6 +10,9 @@ import javax.inject.Inject
 class ChatRepository @Inject constructor(
     private val api: OpenRouterService
 ) {
+    private val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
+    private val questAdapter = moshi.adapter(QuestDto::class.java)
+
     suspend fun completeOnce(model: String, history: List<Pair<String,String>>): String {
         val messages = history.map { (role, content) -> ChatMessageDto(role, content) }
         val res = api.chatCompletion(ChatRequestDto(model = model, messages = messages, stream = false))
@@ -19,5 +24,37 @@ class ChatRepository @Inject constructor(
         val response = api.streamChatCompletion(ChatRequestDto(model = model, messages = messages, stream = true))
         val body = response.body() ?: throw IllegalStateException("Empty body")
         emitAll(SseParser.parseStream(body))
+    }
+
+    suspend fun requestQuest(model: String, prompt: String): QuestDto {
+        val messages = listOf(
+            ChatMessageDto("user", prompt)
+        )
+        val schema: Map<String, Any> = mapOf(
+            "type" to "object",
+            "properties" to mapOf(
+                "title" to mapOf("type" to "string"),
+                "description" to mapOf("type" to "string")
+            ),
+            "required" to listOf("title", "description"),
+            "additionalProperties" to false
+        )
+        val responseFormat = ResponseFormatDto(
+            type = "json_schema",
+            jsonSchema = JsonSchemaDto(
+                name = "quest",
+                schema = schema
+            )
+        )
+        val res = api.questCompletion(
+            ChatRequestDto(
+                model = model,
+                messages = messages,
+                stream = false,
+                responseFormat = responseFormat
+            )
+        )
+        val content = res.choices.firstOrNull()?.message?.content ?: "{}"
+        return questAdapter.fromJson(content) ?: QuestDto("", "")
     }
 }

--- a/app/src/main/java/com/povush/aiadvent/data/ChatRepository.kt
+++ b/app/src/main/java/com/povush/aiadvent/data/ChatRepository.kt
@@ -10,7 +10,7 @@ class ChatRepository @Inject constructor(
 ) {
     private val systemPrompt = """
         Определяй, просит ли пользователь сгенерировать квест.
-        Если да, ответь строго в формате JSON с полями "title" и "description" (2-4 предложения).
+        Если да, ответь строго в формате JSON с полями "title", "description" (2-4 предложения) и "tasks" (список строк).
         Если нет – отвечай обычным текстом.
     """.trimIndent()
 

--- a/app/src/main/java/com/povush/aiadvent/data/ChatRepository.kt
+++ b/app/src/main/java/com/povush/aiadvent/data/ChatRepository.kt
@@ -1,60 +1,36 @@
 package com.povush.aiadvent.data
 
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class ChatRepository @Inject constructor(
-    private val api: OpenRouterService
+    private val api: OpenRouterService,
 ) {
-    private val moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
-    private val questAdapter = moshi.adapter(QuestDto::class.java)
+    private val systemPrompt = """
+        Определяй, просит ли пользователь сгенерировать квест.
+        Если да, ответь строго в формате JSON с полями "title" и "description" (2-4 предложения).
+        Если нет – отвечай обычным текстом.
+    """.trimIndent()
 
-    suspend fun completeOnce(model: String, history: List<Pair<String,String>>): String {
-        val messages = history.map { (role, content) -> ChatMessageDto(role, content) }
-        val res = api.chatCompletion(ChatRequestDto(model = model, messages = messages, stream = false))
+    suspend fun completeOnce(model: String, history: List<Pair<String, String>>): String {
+        val messages = listOf(ChatMessageDto("system", systemPrompt)) +
+            history.map { (role, content) -> ChatMessageDto(role, content) }
+        val res = api.chatCompletion(
+            ChatRequestDto(model = model, messages = messages, stream = false)
+        )
         return res.choices.firstOrNull()?.message?.content ?: ""
     }
 
-    fun streamCompletion(model: String, history: List<Pair<String,String>>): Flow<String> = flow {
-        val messages = history.map { (role, content) -> ChatMessageDto(role, content) }
-        val response = api.streamChatCompletion(ChatRequestDto(model = model, messages = messages, stream = true))
+    fun streamCompletion(model: String, history: List<Pair<String, String>>): Flow<String> = flow {
+        val messages = listOf(ChatMessageDto("system", systemPrompt)) +
+            history.map { (role, content) -> ChatMessageDto(role, content) }
+        val response = api.streamChatCompletion(
+            ChatRequestDto(model = model, messages = messages, stream = true)
+        )
         val body = response.body() ?: throw IllegalStateException("Empty body")
         emitAll(SseParser.parseStream(body))
     }
-
-    suspend fun requestQuest(model: String, prompt: String): QuestDto {
-        val messages = listOf(
-            ChatMessageDto("user", prompt)
-        )
-        val schema: Map<String, Any> = mapOf(
-            "type" to "object",
-            "properties" to mapOf(
-                "title" to mapOf("type" to "string"),
-                "description" to mapOf("type" to "string")
-            ),
-            "required" to listOf("title", "description"),
-            "additionalProperties" to false
-        )
-        val responseFormat = ResponseFormatDto(
-            type = "json_schema",
-            jsonSchema = JsonSchemaDto(
-                name = "quest",
-                schema = schema
-            )
-        )
-        val res = api.questCompletion(
-            ChatRequestDto(
-                model = model,
-                messages = messages,
-                stream = false,
-                responseFormat = responseFormat
-            )
-        )
-        val content = res.choices.firstOrNull()?.message?.content ?: "{}"
-        return questAdapter.fromJson(content) ?: QuestDto("", "")
-    }
 }
+

--- a/app/src/main/java/com/povush/aiadvent/data/Dto.kt
+++ b/app/src/main/java/com/povush/aiadvent/data/Dto.kt
@@ -6,7 +6,7 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class ChatMessageDto(
     val role: String,
-    val content: String
+    val content: String,
 )
 
 @JsonClass(generateAdapter = true)
@@ -22,26 +22,26 @@ data class ChatRequestDto(
 @JsonClass(generateAdapter = true)
 data class ResponseFormatDto(
     val type: String,
-    @Json(name = "json_schema") val jsonSchema: JsonSchemaDto
+    @Json(name = "json_schema") val jsonSchema: JsonSchemaDto,
 )
 
 @JsonClass(generateAdapter = true)
 data class JsonSchemaDto(
     val name: String,
-    val schema: Map<String, Any>
+    val schema: Map<String, Any>,
 )
 
 @JsonClass(generateAdapter = true)
 data class QuestDto(
     val title: String,
-    val description: String
+    val description: String,
 )
 
 @JsonClass(generateAdapter = true)
 data class ChatChoiceDto(
     val index: Int,
     val message: ChatMessageDto?,
-    @Json(name = "finish_reason") val finishReason: String?
+    @Json(name = "finish_reason") val finishReason: String?,
 )
 
 @JsonClass(generateAdapter = true)
@@ -50,21 +50,21 @@ data class ChatResponseDto(
     val object_: String? = null,
     val created: Long? = null,
     val model: String? = null,
-    val choices: List<ChatChoiceDto> = emptyList()
+    val choices: List<ChatChoiceDto> = emptyList(),
 )
 
 // Streaming chunk (SSE line payload: choices[0].delta.content)
 @JsonClass(generateAdapter = true)
 data class ChatDeltaDto(
     val content: String? = null,
-    val role: String? = null
+    val role: String? = null,
 )
 
 @JsonClass(generateAdapter = true)
 data class ChatChunkChoiceDto(
     val index: Int,
     val delta: ChatDeltaDto,
-    @Json(name = "finish_reason") val finishReason: String? = null
+    @Json(name = "finish_reason") val finishReason: String? = null,
 )
 
 @JsonClass(generateAdapter = true)
@@ -73,5 +73,6 @@ data class ChatChunkDto(
     val object_: String? = null,
     val created: Long? = null,
     val model: String? = null,
-    val choices: List<ChatChunkChoiceDto> = emptyList()
+    val choices: List<ChatChunkChoiceDto> = emptyList(),
 )
+

--- a/app/src/main/java/com/povush/aiadvent/data/Dto.kt
+++ b/app/src/main/java/com/povush/aiadvent/data/Dto.kt
@@ -16,6 +16,25 @@ data class ChatRequestDto(
     val stream: Boolean = false,
     @Json(name = "temperature") val temperature: Double? = null,
     @Json(name = "max_tokens") val maxTokens: Int? = null,
+    @Json(name = "response_format") val responseFormat: ResponseFormatDto? = null,
+)
+
+@JsonClass(generateAdapter = true)
+data class ResponseFormatDto(
+    val type: String,
+    @Json(name = "json_schema") val jsonSchema: JsonSchemaDto
+)
+
+@JsonClass(generateAdapter = true)
+data class JsonSchemaDto(
+    val name: String,
+    val schema: Map<String, Any>
+)
+
+@JsonClass(generateAdapter = true)
+data class QuestDto(
+    val title: String,
+    val description: String
 )
 
 @JsonClass(generateAdapter = true)

--- a/app/src/main/java/com/povush/aiadvent/data/Dto.kt
+++ b/app/src/main/java/com/povush/aiadvent/data/Dto.kt
@@ -35,6 +35,7 @@ data class JsonSchemaDto(
 data class QuestDto(
     val title: String,
     val description: String,
+    val tasks: List<String> = emptyList(),
 )
 
 @JsonClass(generateAdapter = true)

--- a/app/src/main/java/com/povush/aiadvent/data/OpenRouterService.kt
+++ b/app/src/main/java/com/povush/aiadvent/data/OpenRouterService.kt
@@ -21,6 +21,11 @@ interface OpenRouterService {
         @Body body: ChatRequestDto
     ): ChatResponseDto
 
+    @POST("chat/completions")
+    suspend fun questCompletion(
+        @Body body: ChatRequestDto
+    ): ChatResponseDto
+
     @Streaming
     @POST("chat/completions")
     suspend fun streamChatCompletion(

--- a/app/src/main/java/com/povush/aiadvent/data/OpenRouterService.kt
+++ b/app/src/main/java/com/povush/aiadvent/data/OpenRouterService.kt
@@ -1,6 +1,5 @@
 package com.povush.aiadvent.data
 
-import com.povush.aiadvent.AppConfig
 import com.povush.aiadvent.BuildConfig
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
@@ -18,18 +17,13 @@ import retrofit2.http.Streaming
 interface OpenRouterService {
     @POST("chat/completions")
     suspend fun chatCompletion(
-        @Body body: ChatRequestDto
-    ): ChatResponseDto
-
-    @POST("chat/completions")
-    suspend fun questCompletion(
-        @Body body: ChatRequestDto
+        @Body body: ChatRequestDto,
     ): ChatResponseDto
 
     @Streaming
     @POST("chat/completions")
     suspend fun streamChatCompletion(
-        @Body body: ChatRequestDto
+        @Body body: ChatRequestDto,
     ): Response<ResponseBody>
 
     companion object {
@@ -64,3 +58,4 @@ interface OpenRouterService {
         }
     }
 }
+

--- a/app/src/main/java/com/povush/aiadvent/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/povush/aiadvent/ui/ChatViewModel.kt
@@ -63,7 +63,12 @@ class ChatViewModel @Inject constructor(
                 val response = repo.completeOnce(state.value.model, history)
                 val quest = runCatching { questAdapter.fromJson(response) }.getOrNull()
                 _state.update { st ->
-                    if (quest != null && quest.title.isNotBlank() && quest.description.isNotBlank()) {
+                    if (
+                        quest != null &&
+                        quest.title.isNotBlank() &&
+                        quest.description.isNotBlank() &&
+                        quest.tasks.isNotEmpty()
+                    ) {
                         st.copy(messages = st.messages + Message("assistant", quest = quest))
                     } else {
                         st.copy(messages = st.messages + Message("assistant", content = response))

--- a/app/src/main/java/com/povush/aiadvent/ui/ChatViewModel.kt
+++ b/app/src/main/java/com/povush/aiadvent/ui/ChatViewModel.kt
@@ -17,7 +17,11 @@ class ChatViewModel @Inject constructor(
     private val repo: ChatRepository
 ) : ViewModel() {
 
-    data class Message(val role: String, val content: String)
+    data class Message(
+        val role: String,
+        val content: String = "",
+        val quest: QuestDto? = null,
+    )
     data class UiState(
         val messages: List<Message> = listOf(
             Message("system", "Привет с планеты Пов-500!"),
@@ -26,7 +30,6 @@ class ChatViewModel @Inject constructor(
         val isStreaming: Boolean = false,
         val model: String = AppConfig.GPT_OSS_20B_FREE,
         val error: String? = null,
-        val quest: QuestDto? = null
     )
 
     private val _state = MutableStateFlow(UiState())
@@ -34,62 +37,29 @@ class ChatViewModel @Inject constructor(
 
     fun onInputChange(value: String) { _state.update { it.copy(input = value) } }
 
-    fun loadQuest() = viewModelScope.launch {
-        try {
-            val prompt = "Сгенерируй квест и верни результат строго в формате JSON с полями: title - название квеста, description - описание квеста в 2-4 предложениях"
-            val quest = repo.requestQuest(state.value.model, prompt)
-            _state.update { it.copy(quest = quest) }
-        } catch (t: Throwable) {
-            _state.update { it.copy(error = t.message ?: "Error") }
-        }
-    }
-
-    fun send(stream: Boolean = true) {
-        val prompt = state.value.input.trim()
-        if (prompt.isEmpty() || state.value.isStreaming) return
+    fun send() {
+        val userInput = state.value.input.trim()
+        if (userInput.isEmpty() || state.value.isStreaming) return
         _state.update {
             it.copy(
                 input = "",
-                messages = it.messages + Message("user", prompt),
+                messages = it.messages + Message("user", userInput),
                 error = null
             )
         }
-        if (stream) sendStreaming() else sendOnce()
-    }
-
-    private fun sendOnce() = viewModelScope.launch {
-        _state.update { it.copy(isStreaming = true) }
-        try {
-            val answer = repo.completeOnce(
-                state.value.model,
-                history = state.value.messages.map { it.role to it.content }
-            )
-            _state.update { it.copy(messages = it.messages + Message("assistant", answer)) }
-        } catch (t: Throwable) {
-            _state.update { it.copy(error = t.message ?: "Error") }
-        } finally {
-            _state.update { it.copy(isStreaming = false) }
-        }
-    }
-
-    private fun sendStreaming() = viewModelScope.launch {
-        _state.update { it.copy(isStreaming = true) }
-        val base = state.value.messages.map { it.role to it.content }
-        val sb = StringBuilder()
-        try {
-            repo.streamCompletion(state.value.model, base).collect { token ->
-                sb.append(token)
-                _state.update { it.copy(messages = it.messages.dropLast(0)) } // trigger
-                // show the partial assistant message by replacing/adding last
+        viewModelScope.launch {
+            _state.update { it.copy(isStreaming = true) }
+            try {
+                val prompt = "Сгенерируй квест по следующему запросу: $userInput. Верни результат строго в формате JSON с полями: title - название квеста, description - описание квеста в 2-4 предложениях"
+                val quest = repo.requestQuest(state.value.model, prompt)
                 _state.update { st ->
-                    val withoutDraft = st.messages.filterIndexed { idx, _ -> idx < base.size }
-                    st.copy(messages = withoutDraft + Message("assistant", sb.toString()))
+                    st.copy(messages = st.messages + Message("assistant", quest = quest))
                 }
+            } catch (t: Throwable) {
+                _state.update { it.copy(error = t.message ?: "Error") }
+            } finally {
+                _state.update { it.copy(isStreaming = false) }
             }
-        } catch (t: Throwable) {
-            _state.update { it.copy(error = t.message) }
-        } finally {
-            _state.update { it.copy(isStreaming = false) }
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+kapt.use.k2=false


### PR DESCRIPTION
## Summary
- Allow requests to specify `response_format` for OpenRouter API calls
- Add quest generation helper using a JSON schema to guarantee `title` and `description`
- Expose dedicated `questCompletion` endpoint in `OpenRouterService`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a17935b3c832e81644f5b90f22430